### PR TITLE
修复pypdf2报错 & 修复输出的Word文件只有姓名的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
 教育部*
 .idea
 __pycache__
+pdf
+pdf_image.png

--- a/app.py
+++ b/app.py
@@ -51,19 +51,20 @@ def convert_to_docx(path):
             cell._element.get_or_add_tcPr().append(parse_xml(border_xml))
             cell.vertical_alignment = WD_ALIGN_VERTICAL.CENTER
 
-        cells[0].text = key
-        cells[1].text = value + "\n"
+        is_last = key == list(extracted_info.keys())[-1]
+        cells[0].text = key + ("" if is_last else "\n") 
+        cells[1].text = value + ("" if is_last else "\n")
 
-        cropped_image_1 = extract_image_from_pdf(path, 1, 1898, 583, 2230, 1026)
-        add_float_picture(doc.add_paragraph(), cropped_image_1, width=Inches(1.2), pos_x=Pt(430), pos_y=Pt(140))
+    cropped_image_1 = extract_image_from_pdf(path, 1, 1898, 583, 2230, 1026)
+    add_float_picture(doc.add_paragraph(), cropped_image_1, width=Inches(1.2), pos_x=Pt(430), pos_y=Pt(140))
 
-        cropped_image_2 = extract_image_from_pdf(path, 1, 300, 2690, 630, 2985)
-        add_float_picture(doc.add_paragraph(), cropped_image_2, width=Inches(1.2), pos_x=Pt(78), pos_y=Pt(643))
+    cropped_image_2 = extract_image_from_pdf(path, 1, 300, 2690, 630, 2985)
+    add_float_picture(doc.add_paragraph(), cropped_image_2, width=Inches(1.2), pos_x=Pt(78), pos_y=Pt(643))
 
-        output_path = path.replace(".pdf", ".docx")
-        doc.save(output_path)
+    output_path = path.replace(".pdf", ".docx")
+    doc.save(output_path)
 
-        return output_path
+    return output_path
 
 @app.route('/')
 def home():

--- a/extract_info.py
+++ b/extract_info.py
@@ -1,11 +1,11 @@
 import re
-import PyPDF2
+from pypdf import PdfReader
 from pypinyin import lazy_pinyin
 
 
 def extract_text_from_pdf(pdf_path):
     pdf_file_obj = open(pdf_path, 'rb')
-    pdf_reader = PyPDF2.PdfReader(pdf_file_obj)
+    pdf_reader = PdfReader(pdf_file_obj)
 
     text = ""
     for page in pdf_reader.pages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2==3.1.2
 lxml== 4.9.3
 MarkupSafe==2.1.3
 pdf2image== 1.16.0
-PyPDF2== 1.26.0
+pypdf==3.17.1
 pypinyin==0.42.0
 python-docx==0.8.11
 Werkzeug==2.2.2


### PR DESCRIPTION
修复前:

![](https://esunr-image-bed.oss-cn-beijing.aliyuncs.com/picgo/202311171355861.png)

修复后:

![](https://esunr-image-bed.oss-cn-beijing.aliyuncs.com/picgo/202311171523340.png)